### PR TITLE
Moving upload-addons pipeline into enterprise group

### DIFF
--- a/.gocd/build.gocd.groovy
+++ b/.gocd/build.gocd.groovy
@@ -236,7 +236,7 @@ GoCD.script {
     }
 
     pipeline('upload-addons') {
-      group = 'go-cd'
+      group = 'enterprise'
 
       environmentVariables = [
           'GO_ENTERPRISE_DIR'         : '../go-enterprise',
@@ -275,13 +275,9 @@ GoCD.script {
           pipeline = 'go-addon-build'
           stage = 'build-addons'
         }
-        dependency('installers') {
-          pipeline = 'installers'
-          stage = 'dist'
-        }
-        dependency('code-sign') {
-          pipeline = 'code-sign'
-          stage = 'metadata'
+        dependency('regression-pg-gauge') {
+          pipeline = 'regression-pg-gauge'
+          stage = 'regression-selenium'
         }
       }
 


### PR DESCRIPTION
Also replaces `installers` and `code-sign` pipeline to `regression-pg-gauge` as upstream of upload-addons pipeline in alignment with how it was for `upload_addons_to_download_server` pipeline