### PR TITLE
Require the addons_build.json as artifact to be fetched by downstream…

### DIFF
--- a/.gocd/build.gocd.groovy
+++ b/.gocd/build.gocd.groovy
@@ -293,6 +293,12 @@ GoCD.script {
           jobs {
             job('upload') {
               elasticProfileId = 'ecs-gocd-dev-build'
+              artifacts {
+                build {
+                  destination = 'addon_builds'
+                  source = 'gocd_addons_compatibility/addon_builds.json'
+                }
+              }
               tasks {
                 add(fetchArtifactTask('meta'))
                 fetchArtifact {


### PR DESCRIPTION
… pipelines

This file is needed by downstream pipelines to identify the corresponding addon versions for the current GoCD server build