### PR TITLE
Add (or replace obsoleted) signing tasks to sign single executables, specifying input and output paths

### DIFF
--- a/.gocd/build.gocd.groovy
+++ b/.gocd/build.gocd.groovy
@@ -197,18 +197,6 @@ GoCD.script {
                 }
               }
             }
-//            job('osx') {
-//              resources = ['mac', 'signer']
-//              tasks {
-//                addAll(cleanTasks())
-//                add(fetchArtifactTask('osx'))
-//                add(fetchArtifactTask('meta'))
-//                bash {
-//                  commandString = 'rake --trace osx:sign osx:upload[${EXPERIMENTAL_DOWNLOAD_BUCKET}]'
-//                  workingDir = 'codesigning'
-//                }
-//              }
-//            }
             job('upload-docker-image') {
               elasticProfileId = 'ecs-gocd-dev-build-dind'
               secureEnvironmentVariables = [

--- a/rakelib/osx.rake
+++ b/rakelib/osx.rake
@@ -23,7 +23,7 @@ namespace :osx do
     dest_archive = File.expand_path(args[:dest_archive] || "#{File.basename(path)}.zip")
 
     fail "You must specify a path to sign" if path.nil?
-    fail "Path #{path} does not exists"  unless File.exist?(path)
+    fail "Path #{path} does not exist"  unless File.exist?(path)
     fail "Path must be a file, not a directory" if File.directory?(path)
 
     dest_dir = File.dirname(dest_archive)

--- a/rakelib/osx.rake
+++ b/rakelib/osx.rake
@@ -1,4 +1,4 @@
-require 'securerandom'
+require "securerandom"
 
 # make sure deps are installed using
 namespace :osx do
@@ -34,13 +34,13 @@ namespace :osx do
     cp path, signed_file
 
     keychain_path = File.expand_path(File.exist?("~/Library/Keychains/codesign.keychain-db") ? "~/Library/Keychains/codesign.keychain-db" : "~/Library/Keychains/codesign.keychain")
-    keychain_passwd = File.read("../signing-keys/codesign.keychain.password")
+    keychain_passwd = "../signing-keys/codesign.keychain.password"
 
-    run("Unlocking keychain", "security unlock-keychain -p #{keychain_passwd.inspect} #{keychain_path.inspect}") do
+    run("Unlocking keychain", "security unlock-keychain -p \"$(cat #{keychain_passwd})\" #{keychain_path}") do
       begin
-        run("Codesigning binary #{signed_file.inspect}", "codesign --force --verify --verbose --sign \"Developer ID Application: ThoughtWorks (LL62P32G5C)\" #{signed_file.inspect}")
+        run("Codesigning binary #{signed_file}", "codesign --force --verify --verbose --sign \"Developer ID Application: ThoughtWorks (LL62P32G5C)\" #{signed_file}")
       ensure
-        run("Locking keychain again", "security lock-keychain #{keychain_path.inspect}")
+        run("Locking keychain again", "security lock-keychain #{keychain_path}")
       end
     end
 

--- a/rakelib/osx.rake
+++ b/rakelib/osx.rake
@@ -26,7 +26,8 @@ namespace :osx do
     fail "Path #{path} does not exists"  unless File.exist?(path)
     fail "Path must be a file, not a directory" if File.directory?(path)
 
-    dest_dir = ensure_clean_dir(File.dirname(dest_archive))
+    dest_dir = File.dirname(dest_archive)
+    mkdir_p dest_dir # don't ensure_clean_dir in case it points to a parent directory
     work_dir = ensure_clean_dir(File.join("tmp", SecureRandom.hex))
     signed_file = File.join(work_dir, File.basename(path))
 

--- a/rakelib/osx.rake
+++ b/rakelib/osx.rake
@@ -18,7 +18,7 @@ namespace :osx do
   end
 
   desc "sign a single osx binary"
-  task :sign_single_binary, [:path, :dest_archive] do |task, args|
+  task :sign_single_binary, [:path, :dest_archive] => [:setup] do |task, args|
     path = args[:path]
     dest_archive = File.expand_path(args[:dest_archive] || "#{File.basename(path)}.zip")
 

--- a/rakelib/win.rake
+++ b/rakelib/win.rake
@@ -42,7 +42,7 @@ namespace :win do
   end
 
   desc "sign a single windows binary"
-  task :sign_single_binary, [:path, :dest_archive] do |task, args|
+  task :sign_single_binary, [:path, :dest_archive] => [:setup] do |task, args|
     path = args[:path]
     dest_archive = File.expand_path(args[:dest_archive] || "#{File.basename(path)}.zip")
 

--- a/rakelib/win.rake
+++ b/rakelib/win.rake
@@ -50,7 +50,7 @@ namespace :win do
     fail "Path #{path} does not exists"  unless File.exist?(path)
     fail "Path must be a file, not a directory" if File.directory?(path)
 
-    dest_dir = ensure_clean_dir(File.dirname(dest_archive))
+    dest_dir = File.dirname(dest_archive)
     work_dir = ensure_clean_dir(File.join("tmp", SecureRandom.hex))
     signed_file = File.join(work_dir, File.basename(path))
 

--- a/rakelib/win.rake
+++ b/rakelib/win.rake
@@ -41,6 +41,38 @@ namespace :win do
     generate_metadata_for_single_dir signing_dir, '*.exe', :win
   end
 
+  desc "sign a single windows binary"
+  task :sign_single_binary, [:path, :dest_archive] do |task, args|
+    path = args[:path]
+    dest_archive = File.expand_path(args[:dest_archive] || "#{File.basename(path)}.zip")
+
+    fail "You must specify a path to sign" if path.nil?
+    fail "Path #{path} does not exists"  unless File.exist?(path)
+    fail "Path must be a file, not a directory" if File.directory?(path)
+
+    dest_dir = ensure_clean_dir(File.dirname(dest_archive))
+    work_dir = ensure_clean_dir(File.join("tmp", SecureRandom.hex))
+    signed_file = File.join(work_dir, File.basename(path))
+
+    cp path, signed_file
+
+    sign_tool = ENV['SIGNTOOL'] || 'C:\Program Files (x86)\Windows Kits\8.1\bin\x64\signtool'
+
+    sh(%Q{"#{sign_tool}" sign /debug /f ../signing-keys/windows-code-sign.p12 /v /t http://timestamp.digicert.com /a "#{signed_file}"})
+    sh(%Q{"#{sign_tool}" sign /debug /f ../signing-keys/windows-code-sign.p12 /v /tr http://timestamp.digicert.com /a /fd sha256 /td sha256 /as "#{signed_file}"})
+
+    sh(%Q{"#{sign_tool}" verify /debug /v /a /pa /hash sha1 "#{signed_file}"})
+    sh(%Q{"#{sign_tool}" verify /debug /v /a /pa /hash sha256 "#{signed_file}"})
+
+    File.utime(0, 0, signed_file)
+
+    cd work_dir do
+      sh("jar -cMf #{dest_archive} .")
+    end
+
+    generate_metadata_for_single_dir dest_dir, '*.zip', :osx
+  end
+
   desc "upload the win binaries, after signing the binaries"
   task :upload, [:bucket_url] => :sign do |t, args|
     bucket_url = args[:bucket_url]


### PR DESCRIPTION
We are using this rake task for `gocd-cli` and `gocd-trial-launcher`, and it would be great to use a specified path instead.