### PR TITLE
Remove dependency on acceptance pipeline

### DIFF
--- a/.gocd/build.gocd.groovy
+++ b/.gocd/build.gocd.groovy
@@ -115,10 +115,6 @@ GoCD.script {
           pipeline = 'regression-SPAs'
           stage = 'Firefox'
         }
-        dependency('acceptance-linux') {
-          pipeline = 'acceptance-linux'
-          stage = 'RunAcceptanceSpecs-plugins'
-        }
       }
 
       stages {


### PR DESCRIPTION
Acceptance pipeline runs only specs related to package repositories. Those specs are moved into regression pipeline now. No need for acceptance pipeline anymore