### PR TITLE
Update gocd versions in post release activities

### DIFF
--- a/.gocd/post_release_github_activities.gocd.groovy
+++ b/.gocd/post_release_github_activities.gocd.groovy
@@ -54,6 +54,114 @@ GoCD.script {
             }
           }
         }
+
+        stage('update-gocd-versions') {
+          artifactCleanupProhibited = false
+          cleanWorkingDir = false
+          fetchMaterials = true
+          environmentVariables = [GITHUB_TOKEN: "{{SECRET:[build-pipelines][GOCD_CI_USER_RELEASE_TOKEN]}}"]
+          jobs {
+            job('update-gocd') {
+              elasticProfileId = 'ecs-gocd-dev-build'
+              tasks {
+                fetchArtifact {
+                  destination = 'codesigning'
+                  file = true
+                  job = 'dist'
+                  pipeline = 'installers/code-sign/PublishStableRelease'
+                  runIf = 'passed'
+                  source = 'dist/meta/version.json'
+                  stage = 'dist'
+                }
+                exec {
+                  commandLine = ['npm', 'install']
+                  runIf = 'passed'
+                  workingDir = 'codesigning'
+                }
+                exec {
+                  commandLine = ['node', 'lib/bump_gocd_version.js']
+                  runIf = 'passed'
+                  workingDir = 'codesigning'
+                }
+              }
+            }
+
+            job('update-go-plugins') {
+              elasticProfileId = 'ecs-gocd-dev-build'
+              tasks {
+                fetchArtifact {
+                  destination = 'codesigning'
+                  file = true
+                  job = 'dist'
+                  pipeline = 'installers/code-sign/PublishStableRelease'
+                  runIf = 'passed'
+                  source = 'dist/meta/version.json'
+                  stage = 'dist'
+                }
+                exec {
+                  commandLine = ['npm', 'install']
+                  runIf = 'passed'
+                  workingDir = 'codesigning'
+                }
+                exec {
+                  commandLine = ['node', 'lib/bump_go_plugins_version.js']
+                  runIf = 'passed'
+                  workingDir = 'codesigning'
+                }
+              }
+            }
+
+            job('update-business_continuity') {
+              elasticProfileId = 'ecs-gocd-dev-build'
+              tasks {
+                fetchArtifact {
+                  destination = 'codesigning'
+                  file = true
+                  job = 'dist'
+                  pipeline = 'installers/code-sign/PublishStableRelease'
+                  runIf = 'passed'
+                  source = 'dist/meta/version.json'
+                  stage = 'dist'
+                }
+                exec {
+                  commandLine = ['npm', 'install']
+                  runIf = 'passed'
+                  workingDir = 'codesigning'
+                }
+                exec {
+                  commandLine = ['node', 'lib/bump_gocd_version_business_continuity.js']
+                  runIf = 'passed'
+                  workingDir = 'codesigning'
+                }
+              }
+            }
+
+            job('update-installer-testing') {
+              elasticProfileId = 'ecs-gocd-dev-build'
+              tasks {
+                fetchArtifact {
+                  destination = 'codesigning'
+                  file = true
+                  job = 'dist'
+                  pipeline = 'installers/code-sign/PublishStableRelease'
+                  runIf = 'passed'
+                  source = 'dist/meta/version.json'
+                  stage = 'dist'
+                }
+                exec {
+                  commandLine = ['npm', 'install']
+                  runIf = 'passed'
+                  workingDir = 'codesigning'
+                }
+                exec {
+                  commandLine = ['node', 'lib/bump_gocd_version_installer_testing.js']
+                  runIf = 'passed'
+                  workingDir = 'codesigning'
+                }
+              }
+            }
+          }
+        }
       }
     }
   }

--- a/lib/bump_go_plugins_version.js
+++ b/lib/bump_go_plugins_version.js
@@ -1,0 +1,88 @@
+const fs = require('fs');
+const childProcess = require('child_process');
+const assert = require('assert');
+const request = require('request');
+const VERSION = require('../version.json');
+
+const GIT_USERNAME = process.env.GIT_USERNAME || bomb('GIT_USERNAME');
+const GIT_PASSWORD = process.env.GIT_PASSWORD || process.env.GITHUB_TOKEN || bomb('GIT_PASSWORD');
+
+const GOCD_VERSION_TO_RELEASE = VERSION.go_version;
+const NEXT_GOCD_VERSION = VERSION.next_go_version;
+
+const CLONE_TO_PATH = './go-plugins';
+const options = {'cwd': CLONE_TO_PATH};
+
+console.log(`Start cloning gocd git repository into ${CLONE_TO_PATH}...`);
+childProcess.execSync(`git clone https://${GIT_USERNAME}:${GIT_PASSWORD}@github.com/gocd/go-plugins ${CLONE_TO_PATH}`);
+console.log(`Done cloning repository...\n`);
+
+const branchName = `bump-gocd-version-to-${GOCD_VERSION_TO_RELEASE}`;
+console.log(`Checking out new branch '${branchName}'..`);
+console.log(childProcess.execSync(`git checkout -b ${branchName}`, options).toString());
+const checkedOutBranch = childProcess.execSync('git branch | grep \\* | cut -d \' \' -f2', options).toString().trim();
+assert.strictEqual(checkedOutBranch, branchName, `Expected current branch to be ${branchName}, but was ${checkedOutBranch}`);
+console.log('Done checking out new branch..');
+
+const gradleFilePath = `${CLONE_TO_PATH}/build.gradle`;
+let gradleFileContent = fs.readFileSync(gradleFilePath, 'utf8');
+
+console.log(`Updating current gocd version from '${GOCD_VERSION_TO_RELEASE}' to '${NEXT_GOCD_VERSION}' in build.gradle...`);
+gradleFileContent = gradleFileContent.replace(
+    `goVersion = '${GOCD_VERSION_TO_RELEASE}'`,
+    `goVersion = '${NEXT_GOCD_VERSION}'`);
+console.log("Done updating.");
+
+fs.writeFileSync(gradleFilePath, gradleFileContent);
+
+console.log('Performing git diff..');
+console.log(childProcess.execSync(`git diff`, options).toString());
+console.log('-----');
+
+const commitMessage = `Bump up GoCD Version to ${NEXT_GOCD_VERSION}`;
+console.log('Committing build.gradle changes...');
+console.log(childProcess.execSync(`git add build.gradle`, options).toString());
+console.log(childProcess.execSync(`git commit --signoff -m "${commitMessage}"`, options).toString());
+console.log('Done committing changes...');
+
+console.log('Pushing branch to origin..');
+console.log(childProcess.execSync(`git push origin ${branchName}`, options).toString());
+console.log('Done Pushing branch to origin..');
+console.log('------------');
+
+console.log('Creating Pull Request..');
+const requestConfig = {
+    'url': `https://api.github.com/repos/gocd/go-plugins/pulls`,
+    'method': 'POST',
+    'auth': {
+        'username': GIT_USERNAME,
+        'password': GIT_PASSWORD
+    },
+    body: {
+        title: `[post-release] ${commitMessage}`,
+        head: `gocd:${branchName}`,
+        base: `master`,
+        maintainer_can_modify: true
+    },
+    json: true,
+    headers: {
+        'User-Agent': GIT_USERNAME,
+        'Accept': 'application/vnd.github.v3+json'
+    }
+};
+
+function sleep(time) {
+    return new Promise((resolve) => setTimeout(resolve, time));
+}
+
+//sleep for 5 secs wait for the code to be pushed and then raise a pull request
+sleep(5000).then(() => {
+    request(requestConfig, (err, res) => {
+        if (err) {
+            return reject(err);
+        }
+        console.log('Done creating pull request..');
+        console.log(res.body);
+        console.log(`Visit: ${res.body.html_url} to see your pull request.`);
+    });
+});

--- a/lib/bump_gocd_version.js
+++ b/lib/bump_gocd_version.js
@@ -1,0 +1,108 @@
+const fs = require('fs');
+const childProcess = require('child_process');
+const assert = require('assert');
+const request = require('request');
+const VERSION = require('../version.json');
+
+const GIT_USERNAME = process.env.GIT_USERNAME || bomb('GIT_USERNAME');
+const GIT_PASSWORD = process.env.GIT_PASSWORD || process.env.GITHUB_TOKEN ||bomb('GIT_PASSWORD');
+
+const GOCD_CURRENT_VERSION = VERSION.previous_go_version;
+const GOCD_VERSION_TO_RELEASE = VERSION.go_version;
+const NEXT_GOCD_VERSION = VERSION.next_go_version;
+
+const CLONE_TO_PATH = './gocd';
+const options = {'cwd': CLONE_TO_PATH};
+
+console.log(`Start cloning gocd git repository into ${CLONE_TO_PATH}...`);
+childProcess.execSync(`git clone https://${GIT_USERNAME}:${GIT_PASSWORD}@github.com/gocd/gocd ${CLONE_TO_PATH}`);
+console.log(`Done cloning repository...\n`);
+
+const branchName = `bump-gocd-version-to-${GOCD_VERSION_TO_RELEASE}`;
+console.log(`Checking out new branch '${branchName}'..`);
+console.log(childProcess.execSync(`git checkout -b ${branchName}`, options).toString());
+const checkedOutBranch = childProcess.execSync('git branch | grep \\* | cut -d \' \' -f2', options).toString().trim();
+assert.strictEqual(checkedOutBranch, branchName, `Expected current branch to be ${branchName}, but was ${checkedOutBranch}`);
+console.log('Done checking out new branch..');
+
+const gradleFilePath = `${CLONE_TO_PATH}/build.gradle`;
+let gradleFileContent = fs.readFileSync(gradleFilePath, 'utf8');
+
+console.log(`Updating previous gocd version from '${GOCD_CURRENT_VERSION}' to '${GOCD_VERSION_TO_RELEASE}' in build.gradle...`);
+gradleFileContent = gradleFileContent.replace(
+    `def GO_VERSION_PREVIOUS = '${GOCD_CURRENT_VERSION}'`,
+    `def GO_VERSION_PREVIOUS = '${GOCD_VERSION_TO_RELEASE}'`);
+console.log("Done updating.");
+
+const splitCurrentAppVersions = GOCD_VERSION_TO_RELEASE.split('.');
+const splitNextAppVersions = NEXT_GOCD_VERSION.split('.');
+
+console.log(`Updating current gocd version from '${GOCD_VERSION_TO_RELEASE}' to '${NEXT_GOCD_VERSION}' in build.gradle...`);
+gradleFileContent = gradleFileContent.replace(
+    `def GO_VERSION_SEGMENTS = [year: ${splitCurrentAppVersions[0]}, releaseInYear: ${splitCurrentAppVersions[1]}, patch: ${splitCurrentAppVersions[2]}]`,
+    `def GO_VERSION_SEGMENTS = [year: ${splitNextAppVersions[0]}, releaseInYear: ${splitNextAppVersions[1]}, patch: ${splitNextAppVersions[2]}]`);
+console.log("Done updating.");
+
+splitNextAppVersions[1] = (+splitNextAppVersions[1]) + 1;
+splitNextAppVersions[2] = 0;
+const newNextAppVersion = splitNextAppVersions.join('.');
+
+console.log(`Updating next gocd version from '${NEXT_GOCD_VERSION}' to '${newNextAppVersion}' in build.gradle...`);
+gradleFileContent = gradleFileContent.replace(
+    `def GO_VERSION_NEXT = '${NEXT_GOCD_VERSION}'`,
+    `def GO_VERSION_NEXT = '${newNextAppVersion}'`);
+console.log("Done updating.");
+
+fs.writeFileSync(gradleFilePath, gradleFileContent);
+
+console.log('Performing git diff..');
+console.log(childProcess.execSync(`git diff`, options).toString());
+console.log('-----');
+
+const commitMessage = `Bump up GoCD Version to ${newNextAppVersion}`;
+console.log('Committing build.gradle changes...');
+console.log(childProcess.execSync(`git add build.gradle`, options).toString());
+console.log(childProcess.execSync(`git commit --signoff -m "${commitMessage}"`, options).toString());
+console.log('Done committing changes...');
+
+console.log('Pushing branch to origin..');
+console.log(childProcess.execSync(`git push origin ${branchName}`, options).toString());
+console.log('Done Pushing branch to origin..');
+console.log('------------');
+
+console.log('Creating Pull Request..');
+const requestConfig = {
+    'url': `https://api.github.com/repos/gocd/gocd/pulls`,
+    'method': 'POST',
+    'auth': {
+        'username': GIT_USERNAME,
+        'password': GIT_PASSWORD
+    },
+    body: {
+        title: `[post-release] ${commitMessage}`,
+        head: `gocd:${branchName}`,
+        base: `master`,
+        maintainer_can_modify: true
+    },
+    json: true,
+    headers: {
+        'User-Agent': GIT_USERNAME,
+        'Accept': 'application/vnd.github.v3+json'
+    }
+};
+
+function sleep(time) {
+    return new Promise((resolve) => setTimeout(resolve, time));
+}
+
+//sleep for 5 secs wait for the code to be pushed and then raise a pull request
+sleep(5000).then(() => {
+    request(requestConfig, (err, res) => {
+        if (err) {
+            return reject(err);
+        }
+        console.log('Done creating pull request..');
+        console.log(res.body);
+        console.log(`Visit: ${res.body.html_url} to see your pull request.`);
+    });
+});

--- a/lib/bump_gocd_version_business_continuity.js
+++ b/lib/bump_gocd_version_business_continuity.js
@@ -1,0 +1,89 @@
+const fs = require('fs');
+const childProcess = require('child_process');
+const assert = require('assert');
+const request = require('request');
+const VERSION = require('../version.json');
+
+const GIT_USERNAME = process.env.GIT_USERNAME || bomb('GIT_USERNAME');
+const GIT_PASSWORD = process.env.GIT_PASSWORD || process.env.GITHUB_TOKEN || bomb('GIT_PASSWORD');
+
+const GOCD_VERSION_TO_RELEASE = VERSION.go_version;
+const NEXT_GOCD_VERSION = VERSION.next_go_version;
+
+const CLONE_TO_PATH = './gocd-business-continuity-test';
+const options = {'cwd': CLONE_TO_PATH};
+
+console.log(`Start cloning gocd git repository into ${CLONE_TO_PATH}...`);
+childProcess.execSync(`git clone https://${GIT_USERNAME}:${GIT_PASSWORD}@github.com/gocd/gocd-business-continuity-test ${CLONE_TO_PATH}`);
+console.log(`Done cloning repository...\n`);
+
+const branchName = `bump-gocd-version-to-${GOCD_VERSION_TO_RELEASE}`;
+console.log(`Checking out new branch '${branchName}'..`);
+console.log(childProcess.execSync(`git checkout -b ${branchName}`, options).toString());
+const checkedOutBranch = childProcess.execSync('git branch | grep \\* | cut -d \' \' -f2', options).toString().trim();
+assert.strictEqual(checkedOutBranch, branchName, `Expected current branch to be ${branchName}, but was ${checkedOutBranch}`);
+console.log('Done checking out new branch..');
+
+const fileName = `pipeline-as-code/BC-testing.gocd.yaml`;
+const filePath = `${CLONE_TO_PATH}/${fileName}`;
+let fileContent = fs.readFileSync(filePath, 'utf8');
+
+console.log(`Updating current gocd version from '${GOCD_VERSION_TO_RELEASE}' to '${NEXT_GOCD_VERSION}' in ${fileName}...`);
+fileContent = fileContent.replace(
+    `GO_VERSION: ${GOCD_VERSION_TO_RELEASE}`,
+    `GO_VERSION: ${NEXT_GOCD_VERSION}`);
+console.log("Done updating.");
+
+fs.writeFileSync(filePath, fileContent);
+
+console.log('Performing git diff..');
+console.log(childProcess.execSync(`git diff`, options).toString());
+console.log('-----');
+
+const commitMessage = `Bump up GoCD Version to ${NEXT_GOCD_VERSION}`;
+console.log('Committing changes...');
+console.log(childProcess.execSync(`git add ${fileName}`, options).toString());
+console.log(childProcess.execSync(`git commit --signoff -m "${commitMessage}"`, options).toString());
+console.log('Done committing changes...');
+
+console.log('Pushing branch to origin..');
+console.log(childProcess.execSync(`git push origin ${branchName}`, options).toString());
+console.log('Done Pushing branch to origin..');
+console.log('------------');
+
+console.log('Creating Pull Request..');
+const requestConfig = {
+    'url': `https://api.github.com/repos/gocd/gocd-business-continuity-test/pulls`,
+    'method': 'POST',
+    'auth': {
+        'username': GIT_USERNAME,
+        'password': GIT_PASSWORD
+    },
+    body: {
+        title: `[post-release] ${commitMessage}`,
+        head: `gocd:${branchName}`,
+        base: `master`,
+        maintainer_can_modify: true
+    },
+    json: true,
+    headers: {
+        'User-Agent': GIT_USERNAME,
+        'Accept': 'application/vnd.github.v3+json'
+    }
+};
+
+function sleep(time) {
+    return new Promise((resolve) => setTimeout(resolve, time));
+}
+
+//sleep for 5 secs wait for the code to be pushed and then raise a pull request
+sleep(5000).then(() => {
+    request(requestConfig, (err, res) => {
+        if (err) {
+            return reject(err);
+        }
+        console.log('Done creating pull request..');
+        console.log(res.body);
+        console.log(`Visit: ${res.body.html_url} to see your pull request.`);
+    });
+});

--- a/lib/bump_gocd_version_installer_testing.js
+++ b/lib/bump_gocd_version_installer_testing.js
@@ -1,0 +1,96 @@
+const fs = require('fs');
+const childProcess = require('child_process');
+const assert = require('assert');
+const request = require('request');
+const VERSION = require('../version.json');
+
+const GIT_USERNAME = process.env.GIT_USERNAME || bomb('GIT_USERNAME');
+const GIT_PASSWORD = process.env.GIT_PASSWORD || process.env.GITHUB_TOKEN || bomb('GIT_PASSWORD');
+
+const GOCD_VERSION_TO_RELEASE = VERSION.go_version;
+const NEXT_GOCD_VERSION = VERSION.next_go_version;
+
+const CLONE_TO_PATH = './installer-testing';
+const options = {'cwd': CLONE_TO_PATH};
+
+console.log(`Start cloning gocd git repository into ${CLONE_TO_PATH}...`);
+childProcess.execSync(`git clone https://${GIT_USERNAME}:${GIT_PASSWORD}@github.com/gocd/installer-testing ${CLONE_TO_PATH}`);
+console.log(`Done cloning repository...\n`);
+
+const branchName = `bump-gocd-version-to-${GOCD_VERSION_TO_RELEASE}`;
+console.log(`Checking out new branch '${branchName}'..`);
+console.log(childProcess.execSync(`git checkout -b ${branchName}`, options).toString());
+const checkedOutBranch = childProcess.execSync('git branch | grep \\* | cut -d \' \' -f2', options).toString().trim();
+assert.strictEqual(checkedOutBranch, branchName, `Expected current branch to be ${branchName}, but was ${checkedOutBranch}`);
+console.log('Done checking out new branch..');
+
+const fileNames = [
+    'pipeline-as-code/Installer-test-with-addons.gocd.yaml',
+    'pipeline-as-code/Upgrade-testing-with-addons.gocd.yaml',
+    'pipeline-as-code/installer-tests.gocd.yaml'
+];
+let fileName;
+for (fileName of fileNames) {
+    const filePath = `${CLONE_TO_PATH}/${fileName}`;
+    let fileContent = fs.readFileSync(filePath, 'utf8');
+
+    console.log(`Updating current gocd version from '${GOCD_VERSION_TO_RELEASE}' to '${NEXT_GOCD_VERSION}' in ${fileName}...`);
+    fileContent = fileContent.replace(
+        `GO_VERSION: ${GOCD_VERSION_TO_RELEASE}`,
+        `GO_VERSION: ${NEXT_GOCD_VERSION}`);
+    console.log("Done updating.");
+
+    fs.writeFileSync(filePath, fileContent);
+
+    console.log('Performing git diff..');
+    console.log(childProcess.execSync(`git diff`, options).toString());
+    console.log('-----');
+
+    const commitMessage = `Bump up GoCD Version to ${NEXT_GOCD_VERSION} in file ${fileName}`;
+    console.log('Committing changes...');
+    console.log(childProcess.execSync(`git add ${fileName}`, options).toString());
+    console.log(childProcess.execSync(`git commit --signoff -m "${commitMessage}"`, options).toString());
+    console.log('Done committing changes...');
+}
+
+console.log('Pushing branch to origin..');
+console.log(childProcess.execSync(`git push origin ${branchName}`, options).toString());
+console.log('Done Pushing branch to origin..');
+console.log('------------');
+
+console.log('Creating Pull Request..');
+const requestConfig = {
+    'url': `https://api.github.com/repos/gocd/installer-testing/pulls`,
+    'method': 'POST',
+    'auth': {
+        'username': GIT_USERNAME,
+        'password': GIT_PASSWORD
+    },
+    body: {
+        title: `[post-release] Bump up GoCD Version to ${NEXT_GOCD_VERSION}`,
+        head: `gocd:${branchName}`,
+        base: `master`,
+        maintainer_can_modify: true
+    },
+    json: true,
+    headers: {
+        'User-Agent': GIT_USERNAME,
+        'Accept': 'application/vnd.github.v3+json'
+    }
+};
+
+function sleep(time) {
+    return new Promise((resolve) => setTimeout(resolve, time));
+}
+
+//sleep for 5 secs wait for the code to be pushed and then raise a pull request
+sleep(5000).then(() => {
+    request(requestConfig, (err, res) => {
+        if (err) {
+            return reject(err);
+        }
+        console.log('Done creating pull request..');
+        console.log(res.body);
+        console.log(`Visit: ${res.body.html_url} to see your pull request.`);
+    });
+});


### PR DESCRIPTION
Automate updating the gocd versions in various github repos
 - gocd
 - go-plugins
 - business-continuity
 - installer-testing

Currently, a PR would be raised with the changes.