### PR TITLE
Make releasing GoCD easier

### DIFF
--- a/.gocd/build.gocd.groovy
+++ b/.gocd/build.gocd.groovy
@@ -401,6 +401,17 @@ GoCD.script {
       }
 
       stages {
+        stage('dummy-stage') {
+          jobs {
+            job('do-nothing') {
+              tasks {
+                bash {
+                  commandString = 'echo'
+                }
+              }
+            }
+          }
+        }
         stage('promote-binaries') {
           approval {
             type = 'manual'


### PR DESCRIPTION
Adds a dummy stage to the PublishStableRelease so that publishing a stable release does not involve
choosing a proper upstream material revision