### PR TITLE
Include architecture/jre info metadata for each binary

### DIFF
--- a/rakelib/deb.rake
+++ b/rakelib/deb.rake
@@ -18,7 +18,7 @@ namespace :deb do
 
     rm_rf signing_dir
     mkdir_p signing_dir
-    Dir["#{deb_source_dir}/*.deb"].each do |f|
+    Dir["#{deb_source_dir}/*.{deb,json}"].each do |f|
       cp f, "#{signing_dir}"
     end
 
@@ -36,7 +36,7 @@ namespace :deb do
       sh("dpkg-sig --verbose --verify '#{f}'")
     end
 
-    generate_metadata_for_single_dir signing_dir, '*.deb', :deb
+    generate_metadata_for_single_dir signing_dir, '*.deb', :deb, { architecture: 'all', jre: { included: false } }
   end
 
   desc "upload the deb binaries, after signing the binaries"

--- a/rakelib/generate_metadata_for_single_dir.rake
+++ b/rakelib/generate_metadata_for_single_dir.rake
@@ -1,27 +1,39 @@
-def generate_metadata_for_single_dir(signing_dir, glob, metadata_key)
+def load_package_metadata(default_package_meta, metadata_file)
+  if File.exist?(metadata_file)
+    meta = JSON.parse(File.read(metadata_file))
+    File.delete(metadata_file)
+    return meta
+  end
+  default_package_meta
+end
+
+def generate_metadata_for_single_dir(signing_dir, glob, metadata_key, defaultPackageMeta)
   cd signing_dir do
     metadata = {}
     Dir[glob].each do |each_file|
-      component = each_file =~ /go-server/ ? 'server' : 'agent'
-      checksums = {
-        md5sum:    Digest::MD5.file(each_file).hexdigest,
-        sha1sum:   Digest::SHA1.file(each_file).hexdigest,
-        sha256sum: Digest::SHA256.file(each_file).hexdigest,
-        sha512sum: Digest::SHA512.file(each_file).hexdigest,
-        file: "#{metadata_key}/#{each_file}",
+      component_type = each_file =~ /go-server/ ? 'server' : 'agent'
+      package_meta = load_package_metadata(defaultPackageMeta, "#{each_file}.json")
+
+      component_key = package_meta['architecture'] == defaultPackageMeta['architecture'] ? component_type : "#{component_type}-#{package_meta['architecture']}"
+      component_meta = {
+        md5sum:       Digest::MD5.file(each_file).hexdigest,
+        sha1sum:      Digest::SHA1.file(each_file).hexdigest,
+        sha256sum:    Digest::SHA256.file(each_file).hexdigest,
+        sha512sum:    Digest::SHA512.file(each_file).hexdigest,
+        file:         "#{metadata_key}/#{each_file}",
       }
 
-      metadata[component] = checksums
+      metadata[component_key] = package_meta.merge(component_meta)
 
-      checksums.each do |k, v|
+      component_meta.each do |k, v|
         next unless k =~ /sum$/
-        open("#{each_file}.#{k}", 'w') {|f| f.puts([v, File.basename(each_file)].join('  '))}
+        open("#{each_file}.#{k}", 'w') { |f| f.puts([v, File.basename(each_file)].join('  ')) }
       end
     end
 
-    json = {metadata_key => metadata}
+    json = { metadata_key => metadata }
 
-    $stderr.puts "Generated checksums: #{JSON.pretty_generate(json)}"
-    open('metadata.json', 'w') {|f| f.puts(JSON.generate(json))}
+    $stderr.puts "Generated metadata: #{JSON.pretty_generate(json)}"
+    open('metadata.json', 'w') { |f| f.puts(JSON.generate(json)) }
   end
 end

--- a/rakelib/osx.rake
+++ b/rakelib/osx.rake
@@ -14,7 +14,7 @@ namespace :osx do
 
     rm_rf signing_dir
     mkdir_p signing_dir
-    Dir["#{osx_source_dir}/*.zip"].each do |f|
+    Dir["#{osx_source_dir}/*.{zip,json}"].each do |f|
       cp f, "#{signing_dir}"
     end
 
@@ -27,7 +27,7 @@ namespace :osx do
 
     rm_rf 'tmp'
 
-    generate_metadata_for_single_dir signing_dir, '*.zip', :osx
+    generate_metadata_for_single_dir signing_dir, '*.zip', :osx, { architecture: 'x64', jre: { included: true } }
   end
 
   desc "upload the osx binaries, after signing the binaries"

--- a/rakelib/rpm.rake
+++ b/rakelib/rpm.rake
@@ -11,7 +11,7 @@ namespace :rpm do
 
     rm_rf signing_dir
     mkdir_p signing_dir
-    Dir["#{rpm_source_dir}/*.rpm"].each do |f|
+    Dir["#{rpm_source_dir}/*.{rpm,json}"].each do |f|
       cp f, "#{signing_dir}"
     end
 
@@ -34,7 +34,7 @@ namespace :rpm do
       sh("rpm --checksig '#{f}'")
     end
 
-    generate_metadata_for_single_dir signing_dir, '*.rpm', :rpm
+    generate_metadata_for_single_dir signing_dir, '*.rpm', :rpm, { architecture: 'all', jre: { included: false } }
   end
 
   desc "upload the rpm binaries, after signing the binaries"

--- a/rakelib/zip.rake
+++ b/rakelib/zip.rake
@@ -13,7 +13,7 @@ namespace :zip do
 
     rm_rf signing_dir
     mkdir_p signing_dir
-    Dir["#{zip_source_dir}/*.zip"].each do |f|
+    Dir["#{zip_source_dir}/*.{zip,json}"].each do |f|
       cp f, "#{signing_dir}"
     end
 
@@ -24,7 +24,7 @@ namespace :zip do
       end
     end
 
-    generate_metadata_for_single_dir signing_dir, "*.zip", :generic
+    generate_metadata_for_single_dir signing_dir, "*.zip", :generic, { architecture: 'all', jre: { included: false } }
   end
 
   desc "upload the zip binaries, after signing the binaries"


### PR DESCRIPTION
Relies on a matching `.json` file alongside the binary containing metadata about that binary; otherwise defaults the values for now. Nothing is using these yet.

Related to https://github.com/gocd/gocd/pull/10888